### PR TITLE
Add slug field to articles and create script for automation

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,6 +14,9 @@ minify:
   disableXML: true
   minifyOutput: true
 
+permalinks:
+  posts: "/:sections/:slug/"
+
 params:
   env: production # to enable google analytics, opengraph, twitter-cards and schema.
   title: The Flip Flop Developer

--- a/content/posts/Big-data/Serie-y-dataframe-en-pandas/index.es.md
+++ b/content/posts/Big-data/Serie-y-dataframe-en-pandas/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "¿Qué son las series y los dataframes? Librería Pandas"
+slug: "que-son-las-series-y-los-dataframes-libreria-pandas"
 date: 2021-05-10T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Big-data/big-data-roles/index.es.md
+++ b/content/posts/Big-data/big-data-roles/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Roles dentro del big data"
+slug: "roles-dentro-del-big-data"
 date: 2021-07-16T00:00:07.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Big-data/porque-me-gustan-los-notebooks/index.es.md
+++ b/content/posts/Big-data/porque-me-gustan-los-notebooks/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Porque me gustan los notebooks de Jupiter"
+slug: "porque-me-gustan-los-notebooks-de-jupiter"
 date: 2021-05-19T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Big-data/quantitative-and-qualitative-variables/index.es.md
+++ b/content/posts/Big-data/quantitative-and-qualitative-variables/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "¿Cual es la diferencia entre variables cuantitativas y cualitativas?"
+slug: "cual-es-la-diferencia-entre-variables-cuantitativas-y-cualitativas"
 date: 2021-05-11T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Big-data/visualizacion de datos/comprendiendo-heatmap/index.es.md
+++ b/content/posts/Big-data/visualizacion de datos/comprendiendo-heatmap/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Comprendiendo los heatmap (mapa de calor)"
+slug: "comprendiendo-los-heatmap-mapa-de-calor"
 date: 2021-04-20T00:00:07.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Big-data/visualizacion de datos/graficas-de-distribucion/index.es.md
+++ b/content/posts/Big-data/visualizacion de datos/graficas-de-distribucion/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Gráficas de distribución"
+slug: "graficas-de-distribucion"
 date: 2021-08-24T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Big-data/visualizacion de datos/graficas-de-relacion/index.es.md
+++ b/content/posts/Big-data/visualizacion de datos/graficas-de-relacion/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Gráficas de relación"
+slug: "graficas-de-relacion"
 date: 2021-06-03T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Design-patterns/2018.07.12.Page-Object.es.md
+++ b/content/posts/Design-patterns/2018.07.12.Page-Object.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Objeto Página (*pageObject*)"
+slug: "objeto-pagina-pageobject"
 date: 2018-07-11T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Design-patterns/2018.07.29.Inyeccion-de-dependencia.es.md
+++ b/content/posts/Design-patterns/2018.07.29.Inyeccion-de-dependencia.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Inyección de dependencia"
+slug: "inyeccion-de-dependencia"
 date: 2018-07-28T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/Comandos-utiles/index.es.md
+++ b/content/posts/Docker/Comandos-utiles/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Comandos útiles"
+slug: "comandos-utiles"
 date: 2021-02-15T00:00:07.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/como-crear-mi-primer-contenedor/index.es.md
+++ b/content/posts/Docker/como-crear-mi-primer-contenedor/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "¿Cómo crear mi primer contenedor?"
+slug: "como-crear-mi-primer-contenedor"
 date: 2021-02-15T00:00:03.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/como-funciona/index.es.md
+++ b/content/posts/Docker/como-funciona/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "¿Cómo funciona Docker?"
+slug: "como-funciona-docker"
 date: 2021-02-15T00:00:02.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/conceptos-basicos/index.es.md
+++ b/content/posts/Docker/conceptos-basicos/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Conceptos básicos"
+slug: "conceptos-basicos"
 date: 2021-02-15T00:00:01.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/optimizacion-de-imagenes/index.es.md
+++ b/content/posts/Docker/optimizacion-de-imagenes/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Optimización de imágenes"
+slug: "optimizacion-de-imagenes"
 date: 2021-02-15T00:00:04.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/persistencia/index.es.md
+++ b/content/posts/Docker/persistencia/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Persistencia"
+slug: "persistencia"
 date: 2021-03-20T00:00:01.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/que-es-docker/index.es.md
+++ b/content/posts/Docker/que-es-docker/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "¿Qué es Docker?"
+slug: "que-es-docker"
 date: 2021-02-15T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Docker/trabaja-con-docker-sin-terminal/index.es.md
+++ b/content/posts/Docker/trabaja-con-docker-sin-terminal/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Trabaja con Docker sin el terminal"
+slug: "trabaja-con-docker-sin-el-terminal"
 date: 2021-03-20T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Firebase/2018.08.05.NodeJS-apps-en-Firebase.es.md
+++ b/content/posts/Firebase/2018.08.05.NodeJS-apps-en-Firebase.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Node.js apps en Firebase"
+slug: "node-js-apps-en-firebase"
 date: 2018-08-04T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Firebase/2018.08.12.Despliegue-automatico-github-en-firebase-hosting.es.md
+++ b/content/posts/Firebase/2018.08.12.Despliegue-automatico-github-en-firebase-hosting.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Despliegue automático en Firebase hosting desde Github"
+slug: "despliegue-automatico-en-firebase-hosting-desde-github"
 date: 2018-08-11T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Firebase/2018.08.19.Usar-sistema-de-plantillas-PUG-en-firebase-hosting.es.md
+++ b/content/posts/Firebase/2018.08.19.Usar-sistema-de-plantillas-PUG-en-firebase-hosting.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Usar PUG en Firebase"
+slug: "usar-pug-en-firebase"
 date: 2018-08-18T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2018.05.21.Testing-from-ui.es.md
+++ b/content/posts/JavaScript/2018.05.21.Testing-from-ui.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Test con un explorador de verdad"
+slug: "test-con-un-explorador-de-verdad"
 date: 2018-05-20T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2018.05.22.Extrar-modulo-ES5.es.md
+++ b/content/posts/JavaScript/2018.05.22.Extrar-modulo-ES5.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Extraer un modulo, testearlo y sustituirlo por el anterior"
+slug: "extraer-un-modulo-testearlo-y-sustituirlo-por-el-anterior"
 date: 2018-05-21T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2018.05.25.Asincronia.es.md
+++ b/content/posts/JavaScript/2018.05.25.Asincronia.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Asincronía"
+slug: "asincronia"
 date: 2018-05-24T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2018.05.31.Promesas.es.md
+++ b/content/posts/JavaScript/2018.05.31.Promesas.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Promesas"
+slug: "promesas"
 date: 2018-05-30T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2018.06.05.Value-object.es.md
+++ b/content/posts/JavaScript/2018.06.05.Value-object.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Value object"
+slug: "value-object"
 date: 2018-06-04T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2018.06.06.MVC.es.md
+++ b/content/posts/JavaScript/2018.06.06.MVC.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Title 1"
+slug: "title-1"
 date: 2018-06-05T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2018.07.01.Extraer-objeto-en-JavaScript.es.md
+++ b/content/posts/JavaScript/2018.07.01.Extraer-objeto-en-JavaScript.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Extrer objeto en JavaScript"
+slug: "extrer-objeto-en-javascript"
 date: 2018-06-30T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2021.01.02.Poner_siempre_llaves_y_return_en_las_funciones.es.md
+++ b/content/posts/JavaScript/2021.01.02.Poner_siempre_llaves_y_return_en_las_funciones.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Poner siempre llaves y return en las funciones"
+slug: "poner-siempre-llaves-y-return-en-las-funciones"
 date: 2021-01-02T18:24:26.134Z
 draft: false
 hideLastModified: false

--- a/content/posts/JavaScript/2021.01.23.Testear-modulos.es.md
+++ b/content/posts/JavaScript/2021.01.23.Testear-modulos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Testear módulos"
+slug: "testear-modulos"
 date: 2021-01-23T09:01:14.381Z
 draft: false
 hideLastModified: false

--- a/content/posts/Projects/2018.12.17.Feeders.es.md
+++ b/content/posts/Projects/2018.12.17.Feeders.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Feeders"
+slug: "feeders"
 date: 2018-12-17T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Python/pypenv-vs-venv.es.md
+++ b/content/posts/Python/pypenv-vs-venv.es.md
@@ -1,5 +1,6 @@
 ---
 title: "pipenv VS venv"
+slug: "pipenv-vs-venv"
 date: 2021-10-14T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Rails/2021.01.23.Guardar-modelos-en-la-base-de-datos.es.md
+++ b/content/posts/Rails/2021.01.23.Guardar-modelos-en-la-base-de-datos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Guardar modelos en la base de datos"
+slug: "guardar-modelos-en-la-base-de-datos"
 date: 2021-01-23T09:01:14.384Z
 draft: false
 hideLastModified: false

--- a/content/posts/Rails/2021.01.23.Migraciones.es.md
+++ b/content/posts/Rails/2021.01.23.Migraciones.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Migraciones"
+slug: "migraciones"
 date: 2021-01-23T09:01:14.383Z
 draft: false
 hideLastModified: false

--- a/content/posts/Rails/2021.01.23.Rollback-una-migracion-concreta.es.md
+++ b/content/posts/Rails/2021.01.23.Rollback-una-migracion-concreta.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Rollback una migración concreta"
+slug: "rollback-una-migracion-concreta"
 date: 2021-01-23T09:01:14.383Z
 draft: false
 hideLastModified: false

--- a/content/posts/Rails/2021.01.23.Validaciones-presente-campo-false.es.md
+++ b/content/posts/Rails/2021.01.23.Validaciones-presente-campo-false.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Validaciones presente campo false"
+slug: "validaciones-presente-campo-false"
 date: 2021-01-23T09:01:14.384Z
 draft: false
 hideLastModified: false

--- a/content/posts/Rails/2021.01.23.helper.es.md
+++ b/content/posts/Rails/2021.01.23.helper.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Helper"
+slug: "helper"
 date: 2021-01-23T09:01:14.383Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2018.02.11.Presentacion-hola-blog.es.md
+++ b/content/posts/Reflexiones/2018.02.11.Presentacion-hola-blog.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Me presento"
+slug: "me-presento"
 date: 2018-02-11T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2018.02.25.Mi-experiencia-en-Udacity-Google-Developer-Challenge-Scholarship-2017-18.es.md
+++ b/content/posts/Reflexiones/2018.02.25.Mi-experiencia-en-Udacity-Google-Developer-Challenge-Scholarship-2017-18.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Udacity Developer Challenge Scholarship"
+slug: "udacity-developer-challenge-scholarship"
 date: 2018-02-25T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2018.03.18.Mi-experiencia-Hackaton-2018.es.md
+++ b/content/posts/Reflexiones/2018.03.18.Mi-experiencia-Hackaton-2018.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Hack for good 2018, Canarias"
+slug: "hack-for-good-2018-canarias"
 date: 2018-03-18T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2018.05.01.Resumen-primer-cuatrimestre.es.md
+++ b/content/posts/Reflexiones/2018.05.01.Resumen-primer-cuatrimestre.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Resumen 2018, primer trimestre"
+slug: "resumen-2018-primer-trimestre"
 date: 2018-04-30T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2018.09.06.Resumen-segundo-trimestre.es.md
+++ b/content/posts/Reflexiones/2018.09.06.Resumen-segundo-trimestre.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Resumen segundo trimestre"
+slug: "resumen-segundo-trimestre"
 date: 2018-09-05T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2019.01.22.Resumen-2018.es.md
+++ b/content/posts/Reflexiones/2019.01.22.Resumen-2018.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Resumen 2018"
+slug: "resumen-2018"
 date: 2019-01-22T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2021.08.18.disciplina-mejor-que-motivacion.es.md
+++ b/content/posts/Reflexiones/2021.08.18.disciplina-mejor-que-motivacion.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Disciplina mejor que motivación"
+slug: "disciplina-mejor-que-motivacion"
 date: 2021-08-18T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2021.09.26 he participado en mi primer datathon.md
+++ b/content/posts/Reflexiones/2021.09.26 he participado en mi primer datathon.md
@@ -1,5 +1,6 @@
 ---
 title: "He participado en mí primer Datathon"
+slug: "he-participado-en-mi-primer-datathon"
 date: 2021-09-26T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/2023.02.23.Ese-momento-en-el-que-eres-un-ejemplo-a-seguir.md
+++ b/content/posts/Reflexiones/2023.02.23.Ese-momento-en-el-que-eres-un-ejemplo-a-seguir.md
@@ -1,5 +1,6 @@
 ---
 title: "Ese momento en el que eres el ejemplo a seguir"
+slug: "ese-momento-en-el-que-eres-el-ejemplo-a-seguir"
 date: 2023-02-23T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/Correos-con-sentido/index.es.md
+++ b/content/posts/Reflexiones/Correos-con-sentido/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Escribir correos con sentido"
+slug: "escribir-correos-con-sentido"
 date: 2021-04-23T00:00:07.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/Mi-experiencia-en-Twitch/index.es.md
+++ b/content/posts/Reflexiones/Mi-experiencia-en-Twitch/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Primeras impresiones de Twitch"
+slug: "primeras-impresiones-de-twitch"
 date: 2021-05-20T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Reflexiones/este-mundo-no-es-en-blanco-y-negro/index.es.md
+++ b/content/posts/Reflexiones/este-mundo-no-es-en-blanco-y-negro/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Este mundo no es en blanco y negro"
+slug: "este-mundo-no-es-en-blanco-y-negro"
 date: 2021-08-06T00:00:07.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.07.31.Curiosidades-de-ruby.es.md
+++ b/content/posts/Ruby/2018.07.31.Curiosidades-de-ruby.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Curiosidades de ruby"
+slug: "curiosidades-de-ruby"
 date: 2018-07-30T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.08.26.Variables.es.md
+++ b/content/posts/Ruby/2018.08.26.Variables.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Variables"
+slug: "variables"
 date: 2018-08-25T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.08.28.Constantes.es.md
+++ b/content/posts/Ruby/2018.08.28.Constantes.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Constantes"
+slug: "constantes"
 date: 2018-08-27T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.08.30.Filtros.es.md
+++ b/content/posts/Ruby/2018.08.30.Filtros.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Filtros"
+slug: "filtros"
 date: 2018-08-29T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.09.02.Blocks-procs-lambda.es.md
+++ b/content/posts/Ruby/2018.09.02.Blocks-procs-lambda.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Blocks procs lambda"
+slug: "blocks-procs-lambda"
 date: 2018-09-01T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.09.04.Yield.es.md
+++ b/content/posts/Ruby/2018.09.04.Yield.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Yield"
+slug: "yield"
 date: 2018-09-03T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.09.09.Test-en-ruby.es.md
+++ b/content/posts/Ruby/2018.09.09.Test-en-ruby.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Test en ruby"
+slug: "test-en-ruby"
 date: 2018-09-08T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.09.16.Ejecutar-un-solo-test.es.md
+++ b/content/posts/Ruby/2018.09.16.Ejecutar-un-solo-test.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Ejecutar un solo test"
+slug: "ejecutar-un-solo-test"
 date: 2018-09-15T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.09.23.Curiosidades-de-ruby-parte-2.es.md
+++ b/content/posts/Ruby/2018.09.23.Curiosidades-de-ruby-parte-2.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Curiosidades de ruby parte 2"
+slug: "curiosidades-de-ruby-parte-2"
 date: 2018-09-23T09:01:14.385Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.09.25.Absence-validator.es.md
+++ b/content/posts/Ruby/2018.09.25.Absence-validator.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Absence validator"
+slug: "absence-validator"
 date: 2018-09-25T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ruby/2018.09.27.Modulos-clases-y-mixn.es.md
+++ b/content/posts/Ruby/2018.09.27.Modulos-clases-y-mixn.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Módulos clases y mixn"
+slug: "modulos-clases-y-mixn"
 date: 2018-09-27T09:01:14.385Z
 draft: false
 hideLastModified: false

--- a/content/posts/Scrum/Facilitar-una-retrospectiva/index.es.md
+++ b/content/posts/Scrum/Facilitar-una-retrospectiva/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Cómo facilitar una retrospectiva"
+slug: "como-facilitar-una-retrospectiva"
 date: 2021-04-30T00:00:07.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Symfony/2018.02.11.Usar-Symfony-desde-0-en-ubuntu-parte-1-PHP.es.md
+++ b/content/posts/Symfony/2018.02.11.Usar-Symfony-desde-0-en-ubuntu-parte-1-PHP.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Instalar PHP"
+slug: "instalar-php"
 date: 2018-02-11T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Symfony/2018.02.13.Usar-Symfony-desde-0-en-ubuntu-parte-2-iniciar-proyecto-Symfony.es.md
+++ b/content/posts/Symfony/2018.02.13.Usar-Symfony-desde-0-en-ubuntu-parte-2-iniciar-proyecto-Symfony.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Iniciar el proyecto Symfony"
+slug: "iniciar-el-proyecto-symfony"
 date: 2018-02-13T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Symfony/2018.02.15.Usar-Symfony-desde-0-en-ubuntu-parte-3-desplegar-en-Heroku.es.md
+++ b/content/posts/Symfony/2018.02.15.Usar-Symfony-desde-0-en-ubuntu-parte-3-desplegar-en-Heroku.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Desplegar en Heroku"
+slug: "desplegar-en-heroku"
 date: 2018-02-15T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Symfony/2018.02.17.Usar-Symfony-desde-0-en-ubuntu-parte-4-configurar-el-IDE.es.md
+++ b/content/posts/Symfony/2018.02.17.Usar-Symfony-desde-0-en-ubuntu-parte-4-configurar-el-IDE.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Configurar el IDE"
+slug: "configurar-el-ide"
 date: 2018-02-17T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Symfony/2018.02.19.Usar-Symfony-desde-0-en-ubuntu-parte-5-primera-pagina-y-controlador.es.md
+++ b/content/posts/Symfony/2018.02.19.Usar-Symfony-desde-0-en-ubuntu-parte-5-primera-pagina-y-controlador.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Primera página y controlador"
+slug: "primera-pagina-y-controlador"
 date: 2018-02-19T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Toma-de-requisitos/2019.03.20.Conceptos-basicos.es.md
+++ b/content/posts/Toma-de-requisitos/2019.03.20.Conceptos-basicos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Conceptos básicos de la toma de requisitos"
+slug: "conceptos-basicos-de-la-toma-de-requisitos"
 date: 2019-03-20T09:01:14.385Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ubuntu/2018.10.10.Cambiar-mensaje-del-bash.es.md
+++ b/content/posts/Ubuntu/2018.10.10.Cambiar-mensaje-del-bash.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Cambiar mensaje del bash"
+slug: "cambiar-mensaje-del-bash"
 date: 2018-10-09T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/Ubuntu/2018.10.12.Ver-recursos-del-sistema-en-tiempo-real.es.md
+++ b/content/posts/Ubuntu/2018.10.12.Ver-recursos-del-sistema-en-tiempo-real.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Ver recursos del sistema en tiempo real"
+slug: "ver-recursos-del-sistema-en-tiempo-real"
 date: 2018-10-11T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/jupyter-notebook/2022.01.26.Que-no-me-gusta-de-los-notebooks.md
+++ b/content/posts/jupyter-notebook/2022.01.26.Que-no-me-gusta-de-los-notebooks.md
@@ -1,5 +1,6 @@
 ---
 title: "Que puede mejorar de los Jupyter Notebooks"
+slug: "que-puede-mejorar-de-los-jupyter-notebooks"
 date: 2022-01-26T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.03.01.Prefacio.es.md
+++ b/content/posts/libros/Clean-Code/2018.03.01.Prefacio.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Prefacio"
+slug: "prefacio"
 date: 2018-03-01T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.03.04.Codigo-limpio.es.md
+++ b/content/posts/libros/Clean-Code/2018.03.04.Codigo-limpio.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Código limpio"
+slug: "codigo-limpio"
 date: 2018-03-04T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.03.08.Nombres-Significativos.es.md
+++ b/content/posts/libros/Clean-Code/2018.03.08.Nombres-Significativos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Nombres significativos"
+slug: "nombres-significativos"
 date: 2018-03-08T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.03.15.Funiones.es.md
+++ b/content/posts/libros/Clean-Code/2018.03.15.Funiones.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Funciones"
+slug: "funciones"
 date: 2018-03-15T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.03.22.Comentarios.es.md
+++ b/content/posts/libros/Clean-Code/2018.03.22.Comentarios.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Comentarios"
+slug: "comentarios"
 date: 2018-03-22T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.03.25.Formato.es.md
+++ b/content/posts/libros/Clean-Code/2018.03.25.Formato.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Formato"
+slug: "formato"
 date: 2018-03-25T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.04.01.Objetos-y-estructuras-de-datos.es.md
+++ b/content/posts/libros/Clean-Code/2018.04.01.Objetos-y-estructuras-de-datos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Objetos y estructuras de datos"
+slug: "objetos-y-estructuras-de-datos"
 date: 2018-03-31T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.04.08.Manejo-de-errores.es.md
+++ b/content/posts/libros/Clean-Code/2018.04.08.Manejo-de-errores.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Manejo de errores"
+slug: "manejo-de-errores"
 date: 2018-04-07T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.04.15.Límites.es.md
+++ b/content/posts/libros/Clean-Code/2018.04.15.Límites.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Límites"
+slug: "limites"
 date: 2018-04-14T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.04.22.Test-Unitarios.es.md
+++ b/content/posts/libros/Clean-Code/2018.04.22.Test-Unitarios.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Test Unitarios"
+slug: "test-unitarios"
 date: 2018-04-21T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.04.29.Clases.es.md
+++ b/content/posts/libros/Clean-Code/2018.04.29.Clases.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Clases"
+slug: "clases"
 date: 2018-04-28T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.05.06.Sistemas.es.md
+++ b/content/posts/libros/Clean-Code/2018.05.06.Sistemas.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Sistemas"
+slug: "sistemas"
 date: 2018-05-05T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.05.27.Concurrencia.es.md
+++ b/content/posts/libros/Clean-Code/2018.05.27.Concurrencia.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Concurrencia"
+slug: "concurrencia"
 date: 2018-05-26T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.06.03.Refinamiento-sucesivo.es.md
+++ b/content/posts/libros/Clean-Code/2018.06.03.Refinamiento-sucesivo.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Refinamiento Sucesivo"
+slug: "refinamiento-sucesivo"
 date: 2018-06-02T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.06.10.JUnit-Internos.es.md
+++ b/content/posts/libros/Clean-Code/2018.06.10.JUnit-Internos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "JUnit Internos"
+slug: "junit-internos"
 date: 2018-06-09T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.06.17.Olores-comentarios-y-entorno.es.md
+++ b/content/posts/libros/Clean-Code/2018.06.17.Olores-comentarios-y-entorno.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Olores del código: comentarios y entorno"
+slug: "olores-del-codigo-comentarios-y-entorno"
 date: 2018-06-16T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.06.24.Olores-funciones-y-nombres.es.md
+++ b/content/posts/libros/Clean-Code/2018.06.24.Olores-funciones-y-nombres.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Olores del código: funciones y nombres"
+slug: "olores-del-codigo-funciones-y-nombres"
 date: 2018-06-23T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Clean-Code/2018.07.15.Olores-test.es.md
+++ b/content/posts/libros/Clean-Code/2018.07.15.Olores-test.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Olores del código: test"
+slug: "olores-del-codigo-test"
 date: 2018-07-14T23:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2018.12.26.asumir-la-responsabilidad-de-nuestros-sentimientos.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2018.12.26.asumir-la-responsabilidad-de-nuestros-sentimientos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Asumir la responsabilidad de nuestros sentimientos"
+slug: "asumir-la-responsabilidad-de-nuestros-sentimientos"
 date: 2018-12-26T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2018.12.26.comunicacion-que-bloquea-la-compasion.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2018.12.26.comunicacion-que-bloquea-la-compasion.es.md
@@ -1,5 +1,6 @@
 ---
 title: "La comunicación que bloquea la compasión"
+slug: "la-comunicacion-que-bloquea-la-compasion"
 date: 2018-12-26T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2018.12.26.dar-desde-el-corazon.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2018.12.26.dar-desde-el-corazon.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Dar desde el corazón"
+slug: "dar-desde-el-corazon"
 date: 2018-12-26T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2018.12.26.identificar-y-expresar-los-sentimientos.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2018.12.26.identificar-y-expresar-los-sentimientos.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Identificar y expresar los sentimientos"
+slug: "identificar-y-expresar-los-sentimientos"
 date: 2018-12-26T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2018.12.26.observar-sin-evaluar.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2018.12.26.observar-sin-evaluar.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Observar sin evaluar"
+slug: "observar-sin-evaluar"
 date: 2018-12-26T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2018.12.27.lo-que-pedimos-a-los-demas-para-enriquecer-nuestra-vida.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2018.12.27.lo-que-pedimos-a-los-demas-para-enriquecer-nuestra-vida.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Lo que pedimos a los demas para enriquecer nuestra vida"
+slug: "lo-que-pedimos-a-los-demas-para-enriquecer-nuestra-vida"
 date: 2018-12-27T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2018.12.28.la-recepcion-empatica.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2018.12.28.la-recepcion-empatica.es.md
@@ -1,5 +1,6 @@
 ---
 title: "La recepcion empatica"
+slug: "la-recepcion-empatica"
 date: 2018-12-28T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2019.01.02.la-conexion-con-uno-mismo-a-traves-de-la-compasion.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2019.01.02.la-conexion-con-uno-mismo-a-traves-de-la-compasion.es.md
@@ -1,5 +1,6 @@
 ---
 title: "La conexion con uno mismo a traves de la compasion"
+slug: "la-conexion-con-uno-mismo-a-traves-de-la-compasion"
 date: 2019-01-02T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2019.01.04.la-expresion-plena-de-la-ira.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2019.01.04.la-expresion-plena-de-la-ira.es.md
@@ -1,5 +1,6 @@
 ---
 title: "La expresion plena de la ira"
+slug: "la-expresion-plena-de-la-ira"
 date: 2019-01-04T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2019.01.05.el-uso-protector-de-la-fuerza.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2019.01.05.el-uso-protector-de-la-fuerza.es.md
@@ -1,5 +1,6 @@
 ---
 title: "El uso protector de la fuerza"
+slug: "el-uso-protector-de-la-fuerza"
 date: 2019-01-05T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2019.01.08.como-liberarnos-nosotros-y-asesorar-a-los-demas.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2019.01.08.como-liberarnos-nosotros-y-asesorar-a-los-demas.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Como liberarnos nosotros y asesorar a los demas"
+slug: "como-liberarnos-nosotros-y-asesorar-a-los-demas"
 date: 2019-01-08T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/libros/Comunicacion-no-violenta/2019.01.09.expresar-agradecimiento-mediante-la-comunicacion-no-violenta.es.md
+++ b/content/posts/libros/Comunicacion-no-violenta/2019.01.09.expresar-agradecimiento-mediante-la-comunicacion-no-violenta.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Expresar agradecimiento mediante la comunicacion no violenta"
+slug: "expresar-agradecimiento-mediante-la-comunicacion-no-violenta"
 date: 2019-01-09T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/ponencia/2021-11-27-coding-is-caring/index.es.md
+++ b/content/posts/ponencia/2021-11-27-coding-is-caring/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "He participado en coding is caring"
+slug: "he-participado-en-coding-is-caring"
 date: 2021-10-31T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/ponencia/2022-11-23-CESINF/index.es.md
+++ b/content/posts/ponencia/2022-11-23-CESINF/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "CESINF 2022"
+slug: "cesinf-2022"
 date: 2022-11-23T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/ponencia/2023-10-Software-Crafters-Barcelona/index.es.md
+++ b/content/posts/ponencia/2023-10-Software-Crafters-Barcelona/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "Software Crafter Barcelona 23"
+slug: "software-crafter-barcelona-23"
 date: 2023-10-23T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/ponencia/CESINF-21/index.es.md
+++ b/content/posts/ponencia/CESINF-21/index.es.md
@@ -1,5 +1,6 @@
 ---
 title: "CESINF 2021 - Código sostenible"
+slug: "cesinf-2021-codigo-sostenible"
 date: 2021-12-02T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/content/posts/tips/2022.03.24.como-controlo-mi-tiempo-con-toggl/index.md
+++ b/content/posts/tips/2022.03.24.como-controlo-mi-tiempo-con-toggl/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Como controlo mi tiempo con Toggl"
+slug: "como-controlo-mi-tiempo-con-toggl"
 date: 2022-03-24T00:00:00.000Z
 draft: false
 hideLastModified: false

--- a/docs/add_slug_to_articles.md
+++ b/docs/add_slug_to_articles.md
@@ -1,0 +1,68 @@
+# Add Slug to Articles Script
+
+## Purpose
+
+This script is designed to add a `slug` field to the metadata section of all Markdown articles in the `/content/posts` directory. The `slug` is generated based on the article title, ensuring it is in lowercase, without special characters (like tildes), and with spaces replaced by hyphens. This field is useful for creating SEO-friendly URLs or organizing articles programmatically.
+
+## How It Works
+
+1. The script scans all `.md` files in the `/content/posts` directory.
+2. It extracts the `title` field from the metadata section of each file.
+3. A `slug` is generated from the title by:
+   - Converting it to lowercase.
+   - Replacing spaces with hyphens.
+   - Removing special characters like tildes.
+4. If the `slug` field does not already exist in the file, it is added immediately after the `title` field.
+
+## Usage Instructions
+
+1. **Save the Script**  
+   Ensure the script is saved as `add_slug_to_articles.sh` in the `/scripts` directory.
+
+2. **Make the Script Executable**  
+   Run the following command to make the script executable:
+   ```bash
+   chmod +x /workspaces/cristiansuarez.dev/scripts/add_slug_to_articles.sh
+   ```
+
+3. **Run the Script**  
+   Execute the script using:
+   ```bash
+   /workspaces/cristiansuarez.dev/scripts/add_slug_to_articles.sh
+   ```
+
+4. **Verify Changes**  
+   After running the script, check the `.md` files in the `/content/posts` directory to ensure the `slug` field has been added correctly.
+
+## Notes
+
+- The script will not overwrite an existing `slug` field. If a file already contains a `slug`, it will be skipped.
+- Ensure all articles have a `title` field in their metadata, as the script relies on it to generate the `slug`.
+- The script is non-destructive and only appends the `slug` field if it is missing.
+
+## Example
+
+### Before Running the Script
+```markdown
+---
+title: "Curiosidades de ruby parte 2"
+date: 2018-09-23T09:01:14.385Z
+draft: false
+hideLastModified: false
+summary: ""
+categories: [Ruby]
+---
+```
+
+### After Running the Script
+```markdown
+---
+title: "Curiosidades de ruby parte 2"
+slug: "curiosidades-de-ruby-parte-2"
+date: 2018-09-23T09:01:14.385Z
+draft: false
+hideLastModified: false
+summary: ""
+categories: [Ruby]
+---
+```

--- a/scripts/add_slug_to_articles.sh
+++ b/scripts/add_slug_to_articles.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Directory containing the articles
+ARTICLES_DIR="/workspaces/cristiansuarez.dev/content/posts"
+
+# Function to generate slug from title
+generate_slug() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -e 's/[áàäâ]/a/g' -e 's/[éèëê]/e/g' -e 's/[íìïî]/i/g' -e 's/[óòöô]/o/g' -e 's/[úùüû]/u/g' -e 's/[^a-z0-9]/-/g' -e 's/--*/-/g' -e 's/^-//' -e 's/-$//'
+}
+
+# Iterate over all Markdown files in the directory
+find "$ARTICLES_DIR" -type f -name "*.md" | while read -r file; do
+  # Extract the title from the file
+  title=$(grep -m 1 "^title:" "$file" | sed 's/title: "\(.*\)"/\1/')
+
+  # Generate the slug
+  slug=$(generate_slug "$title")
+
+  # Check if the slug already exists
+  if ! grep -q "^slug:" "$file"; then
+    # Insert the slug after the title
+    sed -i "/^title:/a slug: \"$slug\"" "$file"
+    echo "Added slug to $file"
+  else
+    echo "Slug already exists in $file"
+  fi
+done


### PR DESCRIPTION
- Added a `slug` field to the metadata of various Markdown articles in the `/content/posts` directory for better SEO and organization.
- Created a script `add_slug_to_articles.sh` to automate the addition of `slug` fields based on article titles.
- The script ensures slugs are generated in lowercase, with spaces replaced by hyphens and special characters removed.
- The script checks for existing slugs to avoid overwriting and appends the slug immediately after the title.